### PR TITLE
Usb drivers

### DIFF
--- a/reactos/drivers/usb/usbehci/hardware.cpp
+++ b/reactos/drivers/usb/usbehci/hardware.cpp
@@ -107,6 +107,10 @@ protected:
 
     // write register
     VOID EHCI_WRITE_REGISTER_ULONG(ULONG Offset, ULONG Value);
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -476,7 +480,7 @@ CUSBHardwareDevice::PnpStart(
     //
     // Initialize the UsbQueue now that we have an AdapterObject.
     //
-    Status = m_UsbQueue->Initialize(PUSBHARDWAREDEVICE(this), m_Adapter, m_MemoryManager, &m_Lock);
+    Status = m_UsbQueue->Initialize(PUSBHARDWAREDEVICE(this), m_Adapter, m_MemoryManager, m_DoubleBuffer, m_DoublePhysBuffer, &m_Lock);
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("Failed to Initialize the UsbQueue\n");

--- a/reactos/drivers/usb/usbehci/hardware.h
+++ b/reactos/drivers/usb/usbehci/hardware.h
@@ -151,8 +151,10 @@ typedef struct _QUEUE_TRANSFER_DESCRIPTOR
     ULONG PhysicalAddr;
     LIST_ENTRY DescriptorEntry;
     ULONG TotalBytesToTransfer;
+    UCHAR Padded[0x3C];             // +0x44
 } QUEUE_TRANSFER_DESCRIPTOR, *PQUEUE_TRANSFER_DESCRIPTOR;
 
+C_ASSERT(sizeof(QUEUE_TRANSFER_DESCRIPTOR) == 0x80);
 C_ASSERT(FIELD_OFFSET(QUEUE_TRANSFER_DESCRIPTOR, PhysicalAddr) == 0x34);
 
 //
@@ -221,8 +223,10 @@ typedef struct _QUEUE_HEAD
     LIST_ENTRY TransferDescriptorListHead;
     PVOID NextQueueHead;
     PVOID Request;
+    UCHAR Padded[0x20];               // +0x60
 } QUEUE_HEAD, *PQUEUE_HEAD;
 
+C_ASSERT(sizeof(QUEUE_HEAD) == 0x80);
 C_ASSERT(sizeof(END_POINT_CHARACTERISTICS) == 4);
 C_ASSERT(sizeof(END_POINT_CAPABILITIES) == 4);
 

--- a/reactos/drivers/usb/usbehci/usb_queue.cpp
+++ b/reactos/drivers/usb/usbehci/usb_queue.cpp
@@ -94,6 +94,10 @@ protected:
 
     // contains the periodic queue heads
     LIST_ENTRY m_PeriodicQueueHeads;
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -121,6 +125,8 @@ CUSBQueue::Initialize(
     IN PUSBHARDWAREDEVICE Hardware,
     IN PDMA_ADAPTER AdapterObject,
     IN PDMAMEMORYMANAGER MemManager,
+    IN PVOID DoubleBuffer,
+    IN ULONG DoublePhysBuffer,
     IN OPTIONAL PKSPIN_LOCK Lock)
 {
     NTSTATUS Status = STATUS_SUCCESS;
@@ -360,7 +366,7 @@ CUSBQueue::CreateUSBRequest(
     NTSTATUS Status;
 
     *OutRequest = NULL;
-    Status = InternalCreateUSBRequest(&UsbRequest);
+    Status = InternalCreateUSBRequest(&UsbRequest, m_DoubleBuffer, m_DoublePhysBuffer);
 
     if (NT_SUCCESS(Status))
     {

--- a/reactos/drivers/usb/usbehci/usb_queue.cpp
+++ b/reactos/drivers/usb/usbehci/usb_queue.cpp
@@ -134,6 +134,11 @@ CUSBQueue::Initialize(
     DPRINT("CUSBQueue::Initialize()\n");
 
     ASSERT(Hardware);
+    ASSERT(DoubleBuffer);
+    ASSERT(DoublePhysBuffer);
+
+    m_DoubleBuffer     = DoubleBuffer;
+    m_DoublePhysBuffer = DoublePhysBuffer;
 
     //
     // store device lock

--- a/reactos/drivers/usb/usbehci/usb_request.cpp
+++ b/reactos/drivers/usb/usbehci/usb_request.cpp
@@ -135,6 +135,9 @@ protected:
     // device speed
     USB_DEVICE_SPEED m_Speed;
 
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //----------------------------------------------------------------------------------------
@@ -145,6 +148,13 @@ CUSBRequest::QueryInterface(
     OUT PVOID* Output)
 {
     return STATUS_UNSUCCESSFUL;
+}
+
+VOID
+CUSBRequest::GetDoubleBuffer(PVOID DoubleBuffer, ULONG DoublePhysBuffer)
+{
+    m_DoubleBuffer     = DoubleBuffer;
+    m_DoublePhysBuffer = DoublePhysBuffer;
 }
 
 //----------------------------------------------------------------------------------------
@@ -1802,7 +1812,7 @@ CUSBRequest::GetInterval()
 NTSTATUS
 NTAPI
 InternalCreateUSBRequest(
-    PUSBREQUEST *OutRequest)
+    PUSBREQUEST *OutRequest, PVOID DoubleBuffer, ULONG DoublePhysBuffer)
 {
     PUSBREQUEST This;
 
@@ -1822,6 +1832,8 @@ InternalCreateUSBRequest(
     // add reference count
     //
     This->AddRef();
+
+    This->GetDoubleBuffer(DoubleBuffer, DoublePhysBuffer);
 
     //
     // return result

--- a/reactos/drivers/usb/usbehci/usbehci.h
+++ b/reactos/drivers/usb/usbehci/usbehci.h
@@ -31,6 +31,6 @@ NTSTATUS NTAPI CreateUSBQueue(PUSBQUEUE *OutUsbQueue);
 //
 // usb_request.cpp
 //
-NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest);
+NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest, PVOID DoubleBuffer, ULONG DoublePhysBuffer);
 
 #endif /* USBEHCI_H__ */

--- a/reactos/drivers/usb/usbohci/hardware.cpp
+++ b/reactos/drivers/usb/usbohci/hardware.cpp
@@ -238,6 +238,7 @@ CUSBHardwareDevice::PnpStart(
     PVOID ResourceBase;
     NTSTATUS Status;
     ULONG Version;
+    PHYSICAL_ADDRESS HighestAddress = {{0xFFFFFFFF, 0}};
 
     DPRINT("CUSBHardwareDevice::PnpStart\n");
     for(Index = 0; Index < TranslatedResources->List[0].PartialResourceList.Count; Index++)
@@ -337,6 +338,21 @@ CUSBHardwareDevice::PnpStart(
         DPRINT1("Failed to acquire dma adapter\n");
         return STATUS_INSUFFICIENT_RESOURCES;
     }
+
+    // create double buffer for transfers
+
+    //FIXME: relation <- (usbstor\disk.c:USBSTOR_HandleQueryProperty()) AdapterDescriptor->MaximumPhysicalPages = 25; //FIXME compute some sane value
+    m_DoubleBuffer = MmAllocateContiguousMemory(25 * PAGE_SIZE, HighestAddress); 
+
+    if ( !m_DoubleBuffer )
+    {
+      DPRINT1("PnpStart: Not created DoubleBuffer!\n");
+      Status = STATUS_INSUFFICIENT_RESOURCES;
+      return Status;
+    }
+    RtlZeroMemory((PVOID)m_DoubleBuffer, 25 * PAGE_SIZE); //it need ?
+
+    m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 
     //
     // Create Common Buffer

--- a/reactos/drivers/usb/usbohci/hardware.cpp
+++ b/reactos/drivers/usb/usbohci/hardware.cpp
@@ -105,6 +105,10 @@ protected:
     volatile LONG m_StatusChangeWorkItemStatus;                                        // work item active status
     ULONG m_SyncFramePhysAddr;                                                         // periodic frame list physical address
     ULONG m_IntervalValue;                                                             // periodic interval value
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -370,7 +374,7 @@ CUSBHardwareDevice::PnpStart(
     //
     // Initialize the UsbQueue now that we have an AdapterObject.
     //
-    Status = m_UsbQueue->Initialize(this, m_Adapter, m_MemoryManager, NULL);
+    Status = m_UsbQueue->Initialize(this, m_Adapter, m_MemoryManager, m_DoubleBuffer, m_DoublePhysBuffer, NULL);
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("Failed to Initialize the UsbQueue\n");

--- a/reactos/drivers/usb/usbohci/usb_queue.cpp
+++ b/reactos/drivers/usb/usbohci/usb_queue.cpp
@@ -114,6 +114,12 @@ CUSBQueue::Initialize(
     m_Hardware = POHCIHARDWAREDEVICE(Hardware);
     ASSERT(m_Hardware);
 
+    ASSERT(DoubleBuffer);
+    ASSERT(DoublePhysBuffer);
+
+    m_DoubleBuffer     = DoubleBuffer;
+    m_DoublePhysBuffer = DoublePhysBuffer;
+
     //
     // get bulk endpoint descriptor
     //

--- a/reactos/drivers/usb/usbohci/usb_queue.cpp
+++ b/reactos/drivers/usb/usbohci/usb_queue.cpp
@@ -66,6 +66,10 @@ protected:
     POHCI_ENDPOINT_DESCRIPTOR m_IsoHeadEndpointDescriptor;                              // isochronous head descriptor
     POHCI_ENDPOINT_DESCRIPTOR * m_InterruptEndpoints;
     LIST_ENTRY m_PendingRequestList;                                                    // pending request list
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -93,6 +97,8 @@ CUSBQueue::Initialize(
     IN PUSBHARDWAREDEVICE Hardware,
     IN PDMA_ADAPTER AdapterObject,
     IN PDMAMEMORYMANAGER MemManager,
+    IN PVOID DoubleBuffer,
+    IN ULONG DoublePhysBuffer,
     IN OPTIONAL PKSPIN_LOCK Lock)
 {
     if (!Hardware)
@@ -356,7 +362,7 @@ CUSBQueue::CreateUSBRequest(
     NTSTATUS Status;
 
     *OutRequest = NULL;
-    Status = InternalCreateUSBRequest(&UsbRequest);
+    Status = InternalCreateUSBRequest(&UsbRequest, m_DoubleBuffer, m_DoublePhysBuffer);
 
     if (NT_SUCCESS(Status))
     {

--- a/reactos/drivers/usb/usbohci/usb_request.cpp
+++ b/reactos/drivers/usb/usbohci/usb_request.cpp
@@ -143,7 +143,18 @@ protected:
     // base buffer
     //
     PVOID m_Base;
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
+
+VOID
+CUSBRequest::GetDoubleBuffer(PVOID DoubleBuffer, ULONG_PTR DoublePhysBuffer)
+{
+    m_DoubleBuffer     = DoubleBuffer;
+    m_DoublePhysBuffer = DoublePhysBuffer;
+}
 
 //----------------------------------------------------------------------------------------
 NTSTATUS
@@ -1965,7 +1976,7 @@ CUSBRequest::CompletionCallback()
 NTSTATUS
 NTAPI
 InternalCreateUSBRequest(
-    PUSBREQUEST *OutRequest)
+    PUSBREQUEST *OutRequest, PVOID DoubleBuffer, ULONG DoublePhysBuffer)
 {
     PUSBREQUEST This;
 
@@ -1985,6 +1996,8 @@ InternalCreateUSBRequest(
     // add reference count
     //
     This->AddRef();
+
+    This->GetDoubleBuffer(DoubleBuffer, DoublePhysBuffer);
 
     //
     // return result

--- a/reactos/drivers/usb/usbohci/usbohci.h
+++ b/reactos/drivers/usb/usbohci/usbohci.h
@@ -48,7 +48,7 @@ NTSTATUS NTAPI CreateUSBQueue(PUSBQUEUE *OutUsbQueue);
 //
 // usb_request.cpp
 //
-NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest);
+NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest, PVOID m_DoubleBuffer, ULONG m_DoublePhysBuffer);
 }
 
 #endif /* USBOHCI_H__ */

--- a/reactos/drivers/usb/usbstor/error.c
+++ b/reactos/drivers/usb/usbstor/error.c
@@ -257,6 +257,28 @@ USBSTOR_ResetHandlerWorkItemRoutine(
     USBSTOR_SendCSW(WorkItemData->Context, WorkItemData->Irp);
 }
 
+NTSTATUS
+NTAPI
+USBSTOR_HandleResetRecover(
+    PVOID ErrorContext)
+{
+    NTSTATUS Status;
+    PERRORHANDLER_WORKITEM_DATA WorkItemData = (PERRORHANDLER_WORKITEM_DATA)ErrorContext;
+    PIRP_CONTEXT Context = WorkItemData->Context;
+
+    // perform Reset Recovery
+    Status = USBSTOR_ResetRecovery(Context->FDODeviceExtension);
+    DPRINT("Index %x, Count %x, ResetRecovery %x\n", Context->ErrorIndex, Context->RetryCount, Status);
+
+    if (NT_SUCCESS(Status))
+    {
+        // now send the CSW 
+        USBSTOR_SendCSW(WorkItemData->Context, WorkItemData->Irp);
+    }
+
+    return Status;
+}
+
 VOID
 NTAPI
 ErrorHandlerWorkItemRoutine(

--- a/reactos/drivers/usb/usbstor/error.c
+++ b/reactos/drivers/usb/usbstor/error.c
@@ -250,19 +250,20 @@ ErrorHandlerWorkItemRoutine(
 {
     PERRORHANDLER_WORKITEM_DATA WorkItemData = (PERRORHANDLER_WORKITEM_DATA)Context;
 
-    if (WorkItemData->Context->ErrorIndex == 2)
+    if (WorkItemData->Context->ErrorIndex == 1)
     {
-        //
-        // reset device
-        //
-        USBSTOR_HandleTransferError(WorkItemData->DeviceObject, WorkItemData->Context);
-    }
-    else
-    {
-        //
-        // clear stall
-        //
+        // clear STALL
         USBSTOR_ResetHandlerWorkItemRoutine(WorkItemData);
+    }
+    else if (WorkItemData->Context->ErrorIndex == 2)
+    {
+        // perform Reset Recovery and send the CSW
+        USBSTOR_HandleResetRecover(WorkItemData);
+    }
+    else if (WorkItemData->Context->ErrorIndex == 3)
+    {
+        // perform Reset Recovery and handle error
+        USBSTOR_HandleTransferError(WorkItemData);
     }
 
     //

--- a/reactos/drivers/usb/usbstor/misc.c
+++ b/reactos/drivers/usb/usbstor/misc.c
@@ -292,7 +292,6 @@ USBSTOR_ClassRequest(
 
 {
     PURB Urb;
-    PUCHAR Buffer;
     NTSTATUS Status;
 
     //
@@ -304,19 +303,6 @@ USBSTOR_ClassRequest(
         //
         // no memory
         //
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    //
-    // allocate 1-byte buffer
-    //
-    Buffer = (PUCHAR)AllocateItem(NonPagedPool, sizeof(UCHAR));
-    if (!Buffer)
-    {
-        //
-        // no memory
-        //
-        FreeItem(Buffer);
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 

--- a/reactos/drivers/usb/usbstor/misc.c
+++ b/reactos/drivers/usb/usbstor/misc.c
@@ -355,6 +355,8 @@ USBSTOR_GetMaxLUN(
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
+    *Buffer = 0;
+
     //
     // execute request
     //
@@ -362,19 +364,34 @@ USBSTOR_GetMaxLUN(
 
     DPRINT("MaxLUN: %x\n", *Buffer);
 
-    if (*Buffer > 0xF)
+    if ( NT_SUCCESS(Status) ) 
     {
-        //
-        // invalid response documented in usb mass storage specification
-        //
-        Status = STATUS_DEVICE_DATA_ERROR;
+        if (*Buffer > 0xF)
+        {
+            //
+            // invalid response documented in usb mass storage specification
+            //
+            Status = STATUS_DEVICE_DATA_ERROR;
+        }
+        else
+        {
+            //
+            // store maxlun
+            //
+            DeviceExtension->MaxLUN = *Buffer;
+        }
     }
     else
     {
         //
-        // store maxlun
+        // "USB Mass Storage Class. Bulk-Only Transport. Revision 1.0"
+        // 3.2  Get Max LUN (class-specific request) :
+        // Devices that do not support multiple LUNs may STALL this command.
         //
-        DeviceExtension->MaxLUN = *Buffer;
+        USBSTOR_ResetDevice(DeviceExtension->LowerDeviceObject, DeviceExtension);
+ 
+        DeviceExtension->MaxLUN = 0;
+        Status = STATUS_SUCCESS;
     }
 
     //

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -93,6 +93,12 @@ USBSTOR_IsCSWValid(
     //
     // sanity checks
     //
+    if (sizeof(CSW) != 0x0d)
+    {
+        DPRINT1("[USBSTOR] Expected sizeof(CSW) == 0x0d but got %x\n", sizeof(CSW));
+        return FALSE;
+    }
+
     if (Context->csw->Signature != CSW_SIGNATURE)
     {
         DPRINT1("[USBSTOR] Expected Signature %x but got %x\n", CSW_SIGNATURE, Context->csw->Signature);
@@ -102,12 +108,6 @@ USBSTOR_IsCSWValid(
     if (Context->csw->Tag != (ULONG)Context->csw)
     {
         DPRINT1("[USBSTOR] Expected Tag %x but got %x\n", (ULONG)Context->csw, Context->csw->Tag);
-        return FALSE;
-    }
-
-    if (Context->csw->Status != 0x00)
-    {
-        DPRINT1("[USBSTOR] Expected Status 0x00 but got %x\n", Context->csw->Status);
         return FALSE;
     }
 

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -395,7 +395,7 @@ USBSTOR_SendCSW(
                                            Context->FDODeviceExtension->InterfaceInformation->Pipes[Context->FDODeviceExtension->BulkInPipeIndex].PipeHandle,
                                            Context->csw,
                                            NULL,
-                                           512, //FIXME
+                                           sizeof(CSW),
                                            USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK,
                                            NULL);
 
@@ -548,7 +548,7 @@ USBSTOR_CBWCompletionRoutine(
                                                Context->FDODeviceExtension->InterfaceInformation->Pipes[Context->FDODeviceExtension->BulkInPipeIndex].PipeHandle,
                                                Context->csw,
                                                NULL,
-                                               512, //FIXME
+                                               sizeof(CSW),
                                                USBD_TRANSFER_DIRECTION_IN | USBD_SHORT_TRANSFER_OK,
                                                NULL);
 

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -223,7 +223,7 @@ USBSTOR_CSWCompletionRoutine(
 
     DPRINT("USBSTOR_CSWCompletionRoutine Status %x\n", Irp->IoStatus.Status);
 
-    if (!NT_SUCCESS(Irp->IoStatus.Information))
+    if (!NT_SUCCESS(Irp->IoStatus.Status))
     {
         if (Context->ErrorIndex == 0)
         {

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -237,7 +237,7 @@ USBSTOR_CSWCompletionRoutine(
             Context->ErrorIndex = 1;
 
             //
-            // clear stall and resend cbw
+            // clear STALL and resend CSW
             //
             Status = USBSTOR_QueueWorkItem(Context, Irp);
             ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);
@@ -498,7 +498,7 @@ USBSTOR_DataCompletionRoutine(
     if (!NT_SUCCESS(Irp->IoStatus.Status))
     {
         //
-        // clear stall and resend cbw
+        // clear STALL and send CSW
         //
         Context->ErrorIndex = 1;
         Status = USBSTOR_QueueWorkItem(Context, Irp);

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -448,9 +448,22 @@ USBSTOR_SendCSW(
 
 
     //
-    // setup completion routine
+    // if error - IRP List (queue) Frozen 
     //
-    IoSetCompletionRoutine(Irp, USBSTOR_CSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    if (Context->FDODeviceExtension->IrpListFreeze)
+    {
+         //
+         // setup completion routine for Request Sense 
+         //
+         IoSetCompletionRoutine(Irp, USBSTOR_SenseCSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    }
+    else
+    {
+         //
+         // setup completion routine
+         //
+         IoSetCompletionRoutine(Irp, USBSTOR_CSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    }
 
     //
     // call driver

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -243,7 +243,7 @@ USBSTOR_CSWCompletionRoutine(
         //
         // perform reset recovery
         //
-        Context->ErrorIndex = 2;
+        Context->ErrorIndex = 3;
         IoFreeIrp(Irp);
         Status = USBSTOR_QueueWorkItem(Context, NULL);
         ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);
@@ -255,7 +255,7 @@ USBSTOR_CSWCompletionRoutine(
         //
         // perform reset recovery
         //
-        Context->ErrorIndex = 2;
+        Context->ErrorIndex = 3;
         IoFreeIrp(Irp);
         Status = USBSTOR_QueueWorkItem(Context, NULL);
         ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);

--- a/reactos/drivers/usb/usbstor/usbstor.h
+++ b/reactos/drivers/usb/usbstor/usbstor.h
@@ -312,7 +312,7 @@ typedef struct
     UCHAR Bytes[16];
 }UFI_UNKNOWN_CMD, *PUFI_UNKNOWN_CMD;
 
-typedef struct
+typedef struct _IRP_CONTEXT
 {
     union
     {
@@ -328,6 +328,8 @@ typedef struct
     PMDL TransferBufferMDL;
     ULONG ErrorIndex;
     ULONG RetryCount;
+    PCDB SenseCDB;
+    struct _IRP_CONTEXT *OriginalContext;
 }IRP_CONTEXT, *PIRP_CONTEXT;
 
 typedef struct _ERRORHANDLER_WORKITEM_DATA

--- a/reactos/drivers/usb/usbuhci/hardware.cpp
+++ b/reactos/drivers/usb/usbuhci/hardware.cpp
@@ -125,6 +125,10 @@ protected:
     PUHCI_TRANSFER_DESCRIPTOR m_StrayDescriptor;                                       // stray descriptor
     KTIMER m_SCETimer;                                                                 // SCE timer
     KDPC m_SCETimerDpc;                                                                // timer dpc
+
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -370,7 +374,7 @@ CUSBHardwareDevice::PnpStart(
     //
     // Initialize the UsbQueue now that we have an AdapterObject.
     //
-    Status = m_UsbQueue->Initialize(PUSBHARDWAREDEVICE(this), m_Adapter, m_MemoryManager, NULL);
+    Status = m_UsbQueue->Initialize(PUSBHARDWAREDEVICE(this), m_Adapter, m_MemoryManager, m_DoubleBuffer, m_DoublePhysBuffer, NULL);
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("Failed to Initialize the UsbQueue\n");

--- a/reactos/drivers/usb/usbuhci/usb_queue.cpp
+++ b/reactos/drivers/usb/usbuhci/usb_queue.cpp
@@ -56,6 +56,9 @@ protected:
     KSPIN_LOCK m_Lock;                                                                  // list lock
     PUHCIHARDWAREDEVICE m_Hardware;                                                     // hardware
     
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
 
 //=================================================================================================
@@ -82,6 +85,8 @@ CUSBQueue::Initialize(
     IN PUSBHARDWAREDEVICE Hardware,
     IN PDMA_ADAPTER AdapterObject,
     IN PDMAMEMORYMANAGER MemManager,
+    IN PVOID DoubleBuffer,
+    IN ULONG DoublePhysBuffer,
     IN OPTIONAL PKSPIN_LOCK Lock)
 {
 
@@ -290,7 +295,7 @@ CUSBQueue::CreateUSBRequest(
     NTSTATUS Status;
 
     *OutRequest = NULL;
-    Status = InternalCreateUSBRequest(&UsbRequest);
+    Status = InternalCreateUSBRequest(&UsbRequest, m_DoubleBuffer, m_DoublePhysBuffer);
 
     if (NT_SUCCESS(Status))
     {

--- a/reactos/drivers/usb/usbuhci/usb_request.cpp
+++ b/reactos/drivers/usb/usbuhci/usb_request.cpp
@@ -133,7 +133,17 @@ protected:
     // base
     PVOID m_Base;
 
+    // double buffer for transfer data
+    PVOID m_DoubleBuffer;                                                             // m_DoubleBuffer = MmAllocateContiguousMemory(...); 
+    ULONG m_DoublePhysBuffer;                                                         // m_DoublePhysBuffer = MmGetPhysicalAddress(m_DoubleBuffer).LowPart;
 };
+
+VOID
+CUSBRequest::GetDoubleBuffer(PVOID DoubleBuffer, ULONG DoublePhysBuffer)
+{
+    m_DoubleBuffer     = DoubleBuffer;
+    m_DoublePhysBuffer = DoublePhysBuffer;
+}
 
 //----------------------------------------------------------------------------------------
 NTSTATUS
@@ -1399,7 +1409,7 @@ CUSBRequest::CompletionCallback()
 NTSTATUS
 NTAPI
 InternalCreateUSBRequest(
-    PUSBREQUEST *OutRequest)
+    PUSBREQUEST *OutRequest, PVOID DoubleBuffer, ULONG DoublePhysBuffer)
 {
     PUSBREQUEST This;
 
@@ -1419,6 +1429,8 @@ InternalCreateUSBRequest(
     // add reference count
     //
     This->AddRef();
+
+    This->GetDoubleBuffer(DoubleBuffer, DoublePhysBuffer);
 
     //
     // return result

--- a/reactos/drivers/usb/usbuhci/usbuhci.h
+++ b/reactos/drivers/usb/usbuhci/usbuhci.h
@@ -45,6 +45,6 @@ NTSTATUS NTAPI CreateUSBQueue(PUSBQUEUE *OutUsbQueue);
 //
 // usb_request.cpp
 //
-NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest);
+NTSTATUS NTAPI InternalCreateUSBRequest(PUSBREQUEST *OutRequest, PVOID m_DoubleBuffer, ULONG m_DoublePhysBuffer);
 
 #endif /* USBUHCI_H__ */

--- a/reactos/lib/drivers/libusb/common_interfaces.h
+++ b/reactos/lib/drivers/libusb/common_interfaces.h
@@ -326,6 +326,10 @@ struct IUSBDevice;
                                                                             \
     STDMETHOD_(ULONG, GetTransferType)( THIS) PURE;                         \
                                                                             \
+    STDMETHOD_(VOID, GetDoubleBuffer)( THIS_                                \
+        IN  PVOID DoubleBuffer,                                             \
+        IN  ULONG DoublePhysBuffer) PURE;                                   \
+                                                                            \
     STDMETHOD_(VOID, GetResultStatus)( THIS_                                \
         OUT OPTIONAL NTSTATUS * NtStatusCode,                               \
         OUT OPTIONAL PULONG UrbStatusCode) PURE;
@@ -347,6 +351,10 @@ struct IUSBDevice;
     STDMETHODIMP_(BOOLEAN) IsRequestComplete(VOID);                         \
                                                                             \
     STDMETHODIMP_(ULONG) GetTransferType(VOID);                             \
+                                                                            \
+    STDMETHODIMP_(VOID) GetDoubleBuffer(                                    \
+        IN  PVOID DoubleBuffer,                                             \
+        IN  ULONG DoublePhysBuffer);                                        \
                                                                             \
     STDMETHODIMP_(VOID) GetResultStatus(                                    \
         OUT OPTIONAL NTSTATUS * NtStatusCode,                               \
@@ -373,6 +381,8 @@ typedef IUSBRequest *PUSBREQUEST;
         IN PUSBHARDWAREDEVICE Hardware,                                     \
         IN PDMA_ADAPTER AdapterObject,                                      \
         IN PDMAMEMORYMANAGER MemManager,                                    \
+        IN PVOID DoubleBuffer,                                              \
+        IN ULONG DoublePhysBuffer,                                          \
         IN OPTIONAL PKSPIN_LOCK Lock) PURE;                                 \
                                                                             \
     STDMETHOD_(NTSTATUS, AddUSBRequest)( THIS_                              \
@@ -390,6 +400,8 @@ typedef IUSBRequest *PUSBREQUEST;
         IN PUSBHARDWAREDEVICE Hardware,                                     \
         IN PDMA_ADAPTER AdapterObject,                                      \
         IN PDMAMEMORYMANAGER MemManager,                                    \
+        IN PVOID DoubleBuffer,                                              \
+        IN ULONG DoublePhysBuffer,                                          \
         IN OPTIONAL PKSPIN_LOCK Lock);                                      \
                                                                             \
     STDMETHODIMP_(NTSTATUS) AddUSBRequest(                                  \

--- a/reactos/lib/drivers/libusb/hub_controller.cpp
+++ b/reactos/lib/drivers/libusb/hub_controller.cpp
@@ -324,7 +324,8 @@ CHubController::QueryStatusChangeEndpoint(
         m_Hardware->GetPortStatus(PortId, &PortStatus, &PortChange);
 
         DPRINT("[%s] Port %d: Status %x, Change %x\n", m_USBType, PortId, PortStatus, PortChange);
-
+DPRINT1("QueryStatusChangeEndpoint: FIXME KeStallExecutionProcessor(100000)\n");
+KeStallExecutionProcessor(100000); //100 msec
 
         //
         // If there's a flag in PortChange return TRUE so the SCE Irp will be completed

--- a/reactos/ntoskrnl/io/iomgr/iomgr.c
+++ b/reactos/ntoskrnl/io/iomgr/iomgr.c
@@ -549,6 +549,15 @@ IoInitSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Call back drivers that asked for */
     IopReinitializeBootDrivers();
 
+    /* HACK: it pause need that PnP manager wait while boot-devices (USB keyboard and USB mass-storage) be enumerated */
+    {
+        LARGE_INTEGER Timeout;
+        Timeout.QuadPart = 2000;                                // 2 second
+        DPRINT1("FIXME: Waiting %lu milliseconds\n", Timeout.LowPart);
+        Timeout.QuadPart *= -10000;                             // convert to 100 ns units (absolute)
+        KeDelayExecutionThread(KernelMode, FALSE, &Timeout);    // perform the wait
+    }
+
     /* Check if this was a ramdisk boot */
     if (!_strnicmp(LoaderBlock->ArcBootDeviceName, "ramdisk(0)", 10))
     {


### PR DESCRIPTION
My changes consist of two groups of commits and single (and independent) commits.

The first group is a double buffering for OHCI and EHCI drivers.
The second group is an error handling for USB mass storage devices (driver USBSTOR).

I offer TEMPORARILY, while not resolved a problem call functions MmGetPhysicalAddress() to use the double buffer.
I.e. allocate in addition continuous area memory (m_DoubleBuffer = MmAllocateContiguousMemory (m_DoubleBufferLen, HighestAddress) ;). As this buffer continuous call MmGetPhysicalAddress() will be made only once: m_DoublePhysBuffer = MmGetPhysicalAddress (m_DoubleBuffer).LowPart;. Depending on a direction of transfer the data is copied from MDL buffers (m_TransferBufferMDL) to m_DoubleBuffer or on the contrary. The main operation is conducted with m_DoubleBuffer.
When the problem with call function MmGetPhysicalAddress() will be solved, it will be necessary to delete branching code only. Proceeding from these reasons, I DID NOT REPLACE a functional, but ADDED it. An example: additional function BuildBulkInterruptDataTransferQueueHead() (\drivers\usb\usbehci\usb_request.cpp). It is used instead of three functions: BuildBulkInterruptTransferQueueHead(), BuildTransferDescriptorChain() and InitDescriptor(). These three functions could be deleted. But I did not begin to do it for the reason described above.
Similar and for OHCI driver. For UHCI driver double buffering is not necessary, there errors are not present.
Thus double buffering solves a problem of call function MmGetPhysicalAddress(). This problem actually does impossible usage USB mass storage devices (EHCI and OHCI controlers).
I tested about one month operation of the modified drivers in VirtualBox, and also on real HW. Result positive. That is already today, without waiting solves of the above described problem (a question - when it will be solved?), it is possible to use USB flash sticks, USB-HDD ... etc.

Other problem in USB - not complete support of error handling for data storage devices (USBSTOR driver). To this class of devices there corresponds the specification "USB Mass Storage Class. Bulk-Only Transport. Revision 1.0". USB host supports access to devices through the commands originally developed for devices which use the Interface of small computer systems (SCSI). Look a file \drivers\usb\usbstor\scsi.c. 
In structure Command Status Wrapper (CSW) there is a field bCSWStatus. bCSWStatus the field specifies, whether the command without an error was completed. Value 0x01 means an error, and the host should immediately issue a REQUEST SENSE SCSI command to receive the information on the status. At present it has not been implemented in USBSTOR driver. I had been made additions and some changes to implement it.
Among mine commits is HACKs (as a rule - time delays). They have been found experimentally.
I want to select especially HACK time delays for 2 seconds for PnP the manager. It does not solve problems, but is harmless. I do not think that it is problem - to wait for 2 seconds simply. You know that PnP the manager is not ideal. Also as well as USB drivers. This HACK solves at once some problems and adds possibility of booting from USB, an also USB keyboard should work at settup (last I not tested).
