### PR TITLE
USBSTOR error handling and RequestSense implementation

### DIFF
--- a/reactos/drivers/usb/usbstor/error.c
+++ b/reactos/drivers/usb/usbstor/error.c
@@ -257,6 +257,28 @@ USBSTOR_ResetHandlerWorkItemRoutine(
     USBSTOR_SendCSW(WorkItemData->Context, WorkItemData->Irp);
 }
 
+NTSTATUS
+NTAPI
+USBSTOR_HandleResetRecover(
+    PVOID ErrorContext)
+{
+    NTSTATUS Status;
+    PERRORHANDLER_WORKITEM_DATA WorkItemData = (PERRORHANDLER_WORKITEM_DATA)ErrorContext;
+    PIRP_CONTEXT Context = WorkItemData->Context;
+
+    // perform Reset Recovery
+    Status = USBSTOR_ResetRecovery(Context->FDODeviceExtension);
+    DPRINT("Index %x, Count %x, ResetRecovery %x\n", Context->ErrorIndex, Context->RetryCount, Status);
+
+    if (NT_SUCCESS(Status))
+    {
+        // now send the CSW 
+        USBSTOR_SendCSW(WorkItemData->Context, WorkItemData->Irp);
+    }
+
+    return Status;
+}
+
 VOID
 NTAPI
 ErrorHandlerWorkItemRoutine(

--- a/reactos/drivers/usb/usbstor/error.c
+++ b/reactos/drivers/usb/usbstor/error.c
@@ -250,19 +250,20 @@ ErrorHandlerWorkItemRoutine(
 {
     PERRORHANDLER_WORKITEM_DATA WorkItemData = (PERRORHANDLER_WORKITEM_DATA)Context;
 
-    if (WorkItemData->Context->ErrorIndex == 2)
+    if (WorkItemData->Context->ErrorIndex == 1)
     {
-        //
-        // reset device
-        //
-        USBSTOR_HandleTransferError(WorkItemData->DeviceObject, WorkItemData->Context);
-    }
-    else
-    {
-        //
-        // clear stall
-        //
+        // clear STALL
         USBSTOR_ResetHandlerWorkItemRoutine(WorkItemData);
+    }
+    else if (WorkItemData->Context->ErrorIndex == 2)
+    {
+        // perform Reset Recovery and send the CSW
+        USBSTOR_HandleResetRecover(WorkItemData);
+    }
+    else if (WorkItemData->Context->ErrorIndex == 3)
+    {
+        // perform Reset Recovery and handle error
+        USBSTOR_HandleTransferError(WorkItemData);
     }
 
     //

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -93,6 +93,12 @@ USBSTOR_IsCSWValid(
     //
     // sanity checks
     //
+    if (sizeof(CSW) != 0x0d)
+    {
+        DPRINT1("[USBSTOR] Expected sizeof(CSW) == 0x0d but got %x\n", sizeof(CSW));
+        return FALSE;
+    }
+
     if (Context->csw->Signature != CSW_SIGNATURE)
     {
         DPRINT1("[USBSTOR] Expected Signature %x but got %x\n", CSW_SIGNATURE, Context->csw->Signature);
@@ -102,12 +108,6 @@ USBSTOR_IsCSWValid(
     if (Context->csw->Tag != (ULONG)Context->csw)
     {
         DPRINT1("[USBSTOR] Expected Tag %x but got %x\n", (ULONG)Context->csw, Context->csw->Tag);
-        return FALSE;
-    }
-
-    if (Context->csw->Status != 0x00)
-    {
-        DPRINT1("[USBSTOR] Expected Status 0x00 but got %x\n", Context->csw->Status);
         return FALSE;
     }
 

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -223,7 +223,7 @@ USBSTOR_CSWCompletionRoutine(
 
     DPRINT("USBSTOR_CSWCompletionRoutine Status %x\n", Irp->IoStatus.Status);
 
-    if (!NT_SUCCESS(Irp->IoStatus.Information))
+    if (!NT_SUCCESS(Irp->IoStatus.Status))
     {
         if (Context->ErrorIndex == 0)
         {

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -237,7 +237,7 @@ USBSTOR_CSWCompletionRoutine(
             Context->ErrorIndex = 1;
 
             //
-            // clear stall and resend cbw
+            // clear STALL and resend CSW
             //
             Status = USBSTOR_QueueWorkItem(Context, Irp);
             ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);
@@ -498,7 +498,7 @@ USBSTOR_DataCompletionRoutine(
     if (!NT_SUCCESS(Irp->IoStatus.Status))
     {
         //
-        // clear stall and resend cbw
+        // clear STALL and send CSW
         //
         Context->ErrorIndex = 1;
         Status = USBSTOR_QueueWorkItem(Context, Irp);

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -448,9 +448,22 @@ USBSTOR_SendCSW(
 
 
     //
-    // setup completion routine
+    // if error - IRP List (queue) Frozen 
     //
-    IoSetCompletionRoutine(Irp, USBSTOR_CSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    if (Context->FDODeviceExtension->IrpListFreeze)
+    {
+         //
+         // setup completion routine for Request Sense 
+         //
+         IoSetCompletionRoutine(Irp, USBSTOR_SenseCSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    }
+    else
+    {
+         //
+         // setup completion routine
+         //
+         IoSetCompletionRoutine(Irp, USBSTOR_CSWCompletionRoutine, Context, TRUE, TRUE, TRUE);
+    }
 
     //
     // call driver

--- a/reactos/drivers/usb/usbstor/scsi.c
+++ b/reactos/drivers/usb/usbstor/scsi.c
@@ -243,7 +243,7 @@ USBSTOR_CSWCompletionRoutine(
         //
         // perform reset recovery
         //
-        Context->ErrorIndex = 2;
+        Context->ErrorIndex = 3;
         IoFreeIrp(Irp);
         Status = USBSTOR_QueueWorkItem(Context, NULL);
         ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);
@@ -255,7 +255,7 @@ USBSTOR_CSWCompletionRoutine(
         //
         // perform reset recovery
         //
-        Context->ErrorIndex = 2;
+        Context->ErrorIndex = 3;
         IoFreeIrp(Irp);
         Status = USBSTOR_QueueWorkItem(Context, NULL);
         ASSERT(Status == STATUS_MORE_PROCESSING_REQUIRED);

--- a/reactos/drivers/usb/usbstor/usbstor.h
+++ b/reactos/drivers/usb/usbstor/usbstor.h
@@ -312,7 +312,7 @@ typedef struct
     UCHAR Bytes[16];
 }UFI_UNKNOWN_CMD, *PUFI_UNKNOWN_CMD;
 
-typedef struct
+typedef struct _IRP_CONTEXT
 {
     union
     {
@@ -328,6 +328,8 @@ typedef struct
     PMDL TransferBufferMDL;
     ULONG ErrorIndex;
     ULONG RetryCount;
+    PCDB SenseCDB;
+    struct _IRP_CONTEXT *OriginalContext;
 }IRP_CONTEXT, *PIRP_CONTEXT;
 
 typedef struct _ERRORHANDLER_WORKITEM_DATA


### PR DESCRIPTION
Now in USBSTOR driver not complete support of error handling for data storage devices (USBSTOR driver). To this class of devices there corresponds the specification "USB Mass Storage Class. Bulk-Only Transport. Revision 1.0". USB the host supports access to devices through the commands originally developed for devices which use the Interface of small computer systems (SCSI). Look a file \drivers\usb\usbstor\scsi.c. 
In structure Command Status Wrapper (CSW) there is a field bCSWStatus. bCSWStatus the field specifies, whether the command without an error was completed. Value 0x01 means an error, and the host should immediately issue a REQUEST SENSE SCSI command to receive the information on the status. At present it has not been implemented in USBSTOR driver. I had been made additions and some changes to implement it.

